### PR TITLE
fix: containerApps.ts should target correct endpoint

### DIFF
--- a/sdk/appservice/arm-appservice/src/operations/containerApps.ts
+++ b/sdk/appservice/arm-appservice/src/operations/containerApps.ts
@@ -443,7 +443,7 @@ export class ContainerAppsImpl implements ContainerApps {
 const serializer = coreClient.createSerializer(Mappers, /* isXml */ false);
 
 const listBySubscriptionOperationSpec: coreClient.OperationSpec = {
-  path: "/subscriptions/{subscriptionId}/providers/Microsoft.Web/containerApps",
+  path: "/subscriptions/{subscriptionId}/providers/Microsoft.App/containerApps",
   httpMethod: "GET",
   responses: {
     200: {
@@ -460,7 +460,7 @@ const listBySubscriptionOperationSpec: coreClient.OperationSpec = {
 };
 const listByResourceGroupOperationSpec: coreClient.OperationSpec = {
   path:
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/containerApps",
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/containerApps",
   httpMethod: "GET",
   responses: {
     200: {


### PR DESCRIPTION
### Packages impacted by this PR

`@azure/arm-appservice`

### Issues associated with this PR


### Describe the problem that is addressed by this PR

Azure Container Apps used to use `Microsoft.Web` as the location for Azure container apps, it has moved to `Microsoft.App`.  The code does not reflect that and so container app lookups fail at present. This should fix it.

See https://learn.microsoft.com/en-us/azure/templates/microsoft.web/containerapps?pivots=deployment-language-bicep#remarks

> This resource type has migrated to the Microsoft.App namespace. For the new resource type, see [Microsoft.App containerApps](https://learn.microsoft.com/en-us/azure/templates/microsoft.app/containerapps).
> 
> For information about the migration, see [Action Required: Namespace migration from Microsoft.Web to Microsoft.App in March 2022](https://github.com/microsoft/azure-container-apps/issues/109).

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

N/A

### Are there test cases added in this PR? _(If not, why?)_

Doesn't appear to be covered by tests - perhaps I'm wrong?

### Provide a list of related PRs _(if any)_

N/A

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
